### PR TITLE
http: backport Clone method so previous Go versions work too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.12.x, 1.13.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest] # TODO:, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.12.x, 1.13.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Test
+      run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![test:status](https://github.com/gmarik/cdp-proxy/workflows/Test/badge.svg)
+
 ## About
 
 [cdp-proxy] is a mitm style HTTP proxy and middleware leveraging Chrome DevTools for UI, written in [Go].


### PR DESCRIPTION
- otherwise it's Go1.13 only