### PR TITLE
support multiple concurrent clients

### DIFF
--- a/main/cdp-proxy/http.go
+++ b/main/cdp-proxy/http.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+var proxy = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	u := *r.URL
+	u.Host = r.Host
+	u.Scheme = "http"
+
+	if _, p, _ := net.SplitHostPort(r.Host); p == "443" {
+		u.Scheme = "https"
+	}
+
+	log.Printf("[proxy] %s", u.String())
+
+	if r.Method == http.MethodConnect {
+		newTunnel(&u).ServeHTTP(w, r)
+	} else {
+		newForwardProxy(&u).ServeHTTP(w, r)
+	}
+})
+
+func newTunnel(u *url.URL) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpErr := func(code int, err error) {
+			log.Printf("[CONNECT]: error=%v", err)
+			http.Error(w, http.StatusText(code), code)
+		}
+		log.Printf("[CONNECT]: start:%s", u.Host)
+		defer log.Printf("[CONNECT]: done: %s", u.Host)
+
+		dconn, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
+		if err != nil {
+			httpErr(http.StatusServiceUnavailable, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		} else {
+			log.Println("http.Flusher: unavailable")
+		}
+
+		var sconn net.Conn
+		if h, ok := w.(http.Hijacker); !ok {
+			httpErr(http.StatusInternalServerError, fmt.Errorf("http.Hijacker: unavailable"))
+			return
+		} else {
+			conn, _, err := h.Hijack()
+			if err != nil {
+				httpErr(http.StatusServiceUnavailable, err)
+				return
+			}
+			sconn = conn
+		}
+
+		type readWriteCloser interface {
+			net.Conn
+			CloseRead() error
+			CloseWrite() error
+		}
+
+		var src, dst = sconn.(readWriteCloser), dconn.(readWriteCloser)
+		// TODO:
+		var done = make(chan struct{})
+		go func() {
+			n, err := io.Copy(src, dst)
+			log.Printf("src<-dst: n=%d error=%v", n, err)
+			dst.CloseRead()
+			src.CloseWrite()
+			done <- struct{}{}
+		}()
+		go func() {
+			n, err := io.Copy(dst, src)
+			log.Printf("src->dst: n=%d error=%v", n, err)
+			dst.CloseWrite()
+			src.CloseRead()
+			done <- struct{}{}
+		}()
+		<-done
+		<-done
+	})
+}
+
+func newForwardProxy(target *url.URL) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			// TODO:
+			req.Host = target.Host
+			if _, ok := req.Header["User-Agent"]; !ok {
+				req.Header.Set("User-Agent", "")
+			}
+		},
+		// Transport: loggingTransport(http.DefaultTransport.RoundTrip),
+	}
+}
+
+type loggingTransport func(*http.Request) (*http.Response, error)
+
+func (lt loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	bs, _ := httputil.DumpRequestOut(r, false)
+	log.Println("REQ:", string(bs))
+	re, err := lt(r)
+	bs, _ = httputil.DumpResponse(re, false)
+	log.Println("RES:", string(bs))
+	return re, err
+}

--- a/main/cdp-proxy/httpcdp/body_store.go
+++ b/main/cdp-proxy/httpcdp/body_store.go
@@ -1,0 +1,30 @@
+package httpcdp
+
+import (
+	"bytes"
+	"sync"
+)
+
+type bodyStore struct {
+	m sync.Map
+}
+
+func newStore() *bodyStore {
+	return &bodyStore{}
+}
+
+func (bs *bodyStore) Load(key string) (*bytes.Buffer, bool) {
+	val, ok := bs.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	if buf, ok := val.(*bytes.Buffer); ok {
+		return buf, true
+	}
+	return nil, false
+}
+
+func (bs *bodyStore) LoadOrStore(key string, buf *bytes.Buffer) (actual *bytes.Buffer, loaded bool) {
+	val, ok := bs.m.LoadOrStore(key, buf)
+	return val.(*bytes.Buffer), ok
+}

--- a/main/cdp-proxy/httpcdp/cdp.go
+++ b/main/cdp-proxy/httpcdp/cdp.go
@@ -1,0 +1,89 @@
+package httpcdp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+// devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=localhost:9229/cdp-proxy
+
+// https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
+// conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"method": "Page.disable","params":{}}`)))
+func handleCDP(ctx context.Context, conn *websocket.Conn, e event) error {
+	switch m := e.Method; {
+	case m == "Page.canScreencast" ||
+		m == "Network.canEmulateNetworkConditions" ||
+		m == "Emulation.canEmulate":
+		respond(conn, e.ID, `{"result":false}`)
+	case m == "Page.getResourceTree":
+		// Window decoration
+		respond(conn, e.ID,
+			`{"frameTree": { "frame":{"id":1,"url":"http://cdp-proxy","mimeType":"other"},"childFrames":[],"resources":[]}}`,
+		)
+	case m == "Network.getResponseBody":
+		params, ok := e.Params.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		e.reqID, ok = params["requestId"].(string)
+		if !ok {
+			return nil
+		}
+
+		if buf, ok := store.Load(e.reqID); !ok {
+			respond(conn, e.ID, `{"body":"","base64Encoded":true}`)
+		} else {
+			result := map[string]interface{}{
+				"base64Encoded": true,
+				"body":          base64.StdEncoding.Strict().EncodeToString(buf.Bytes()),
+			}
+
+			data, err := json.Marshal(result)
+			if err != nil {
+				log.Printf("json.Marshal: error=%q", err)
+				return nil
+			}
+
+			// https://chromedevtools.github.io/devtools-protocol/1-2/Network#method-getResponseBody
+			respond(conn, e.ID, string(data))
+		}
+	default:
+		respond(conn, e.ID, `{}`)
+	}
+
+	return nil
+}
+
+func (s *Server) metadata(w http.ResponseWriter, r *http.Request) {
+	// NOTE:
+	// devtoolsFrontendUrl is not respected when opened from `chrome://inspect`
+	var (
+		hostPort = s.HostPort
+		wsURL    = hostPort + "/cdp"
+	)
+	fmt.Fprintf(w, `[{
+			"id": "cdp-proxy",
+			"title": "cdp-proxy",
+			"type": "proxy",
+			"description": "cdp-proxy requests",
+			"faviconUrl": "https://nodejs.org/static/favicon.ico",
+			"url": %q,
+			"devtoolsFrontendUrl": "ws=%s",
+			"webSocketDebuggerUrl": "ws://%s"
+		}]`, hostPort, wsURL, wsURL)
+}
+
+func writeConn(conn *websocket.Conn, p []byte) (int, error) {
+	log.Printf("[CDP<-] %.120s", string(p))
+	return len(p), conn.WriteMessage(websocket.TextMessage, p)
+}
+
+func respond(conn *websocket.Conn, id int, p string) (int, error) {
+	return writeConn(conn, []byte(fmt.Sprintf(`{"id":%d,"result":%s}`, id, p)))
+}

--- a/main/cdp-proxy/httpcdp/http.go
+++ b/main/cdp-proxy/httpcdp/http.go
@@ -3,8 +3,6 @@ package httpcdp
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,6 +13,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+var store = newStore()
+
 var vlog = log.New(ioutil.Discard, "", log.Lshortfile)
 
 var wsUpgrader = &websocket.Upgrader{
@@ -24,185 +24,151 @@ var wsUpgrader = &websocket.Upgrader{
 }
 
 type eventReader interface {
-	ReadEvent(context.Context) event
+	ReadEvent(context.Context, *event) error
+	Close()
 }
 
 type entityStore interface {
 	Get(reqID string) io.Writer
 }
 
-func Devtools(er eventReader) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var u = r.URL
-
-		// `/json` is too noisy
-		if false == strings.HasPrefix(u.Path, "/json") {
-			log.Printf("HTTP: %s\n", u.String())
-			defer log.Printf("HTTP: %s: done\n", u.String())
-		}
-
-		switch {
-		case u.Path == "/":
-			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprintf(w, `go to <b>chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:9229/cdp-proxy</b>`)
-		case u.Path == "/json":
-			// https://chromedevtools.github.io/devtools-protocol/#get-json-or-jsonlist
-			metadata(w, r)
-		case u.Path == "/cdp-proxy":
-			conn, err := wsUpgrader.Upgrade(w, r, nil)
-			if err != nil {
-				log.Printf("HTTP: ws.Upgrader.Upgrade: error=%q", err)
-				code := http.StatusServiceUnavailable
-				http.Error(w, http.StatusText(code), code)
-				return
-			}
-
-			if err := handleConn(er, conn); err != nil {
-				log.Printf("handleCOnn: error=%q\n", err)
-			}
-		}
-	})
+type Server struct {
+	// Debug is a CSV of http prefixes to log requests of. Default: ""
+	Verbose     string
+	Eventbus    *eventBus
+	HostPort    string
+	verboseList []string
 }
 
-func metadata(w http.ResponseWriter, r *http.Request) {
-	// chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=localhost:9229/devtools/cdp-proxy
-
-	// NOTE:
-	// devtoolsFrontendUrl is not respected when opened from `chrome://inspect`
-	host := "localhost:9229"
-	wsURL := host + "/cdp-proxy"
-	fmt.Fprintf(w, `[{
-			"id": "cdp-proxy",
-			"type": "proxy",
-			"title": "cdp-proxy",
-			"description": "cdp-proxy requests",
-			"faviconUrl": "https://nodejs.org/static/favicon.ico",
-			"url": "localhost:8080",
-			"devtoolsFrontendUrl": "ws=%s",
-			"webSocketDebuggerUrl": "ws://%s"
-		}]`, wsURL, wsURL)
+func (h *Server) init() {
+	if h.Verbose != "" {
+		h.verboseList = strings.Split(h.Verbose, ",")
+	}
 }
 
-func handleConn(er eventReader, conn *websocket.Conn) error {
-	ctx, cancel_Fn := context.WithCancel(context.Background())
-	defer conn.Close()
-	defer cancel_Fn()
+func (s *Server) ListenAndServe(ctx context.Context) error {
+	s.init()
 
-	const buffer_Size = 100 // totally random
-	httpEventsc := make(chan event, buffer_Size)
-	cdpEventsc := make(chan event, buffer_Size)
-
-	bodystore := make(map[string]*bytes.Buffer)
-
+	errc := make(chan error)
 	go func() {
-		defer cancel_Fn()
-		for {
-			var e = er.ReadEvent(ctx)
-			select {
-			case <-ctx.Done():
-				return
-			// read events into buffered channel so no events are lost
-			case httpEventsc <- e:
-			}
+		if err := http.ListenAndServe(s.HostPort, http.HandlerFunc(s.serveHTTP)); err != nil {
+			errc <- fmt.Errorf("http.ListenAndServe: %w", err)
 		}
 	}()
 
-	writeConn := func(p []byte) (int, error) {
-		log.Printf("[CDP<-] %.120s", string(p))
-		return len(p), conn.WriteMessage(websocket.TextMessage, p)
+	return <-errc
+}
+
+func (h *Server) isVerbose(path string) bool {
+	for i := range h.verboseList {
+		if strings.HasPrefix(path, h.verboseList[i]) {
+			log.Printf("OK %q: %q, %#v\n", path, h.verboseList[i], h.verboseList)
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if u, p := r.URL, r.URL.Path; len(p) > 1 && p[0] == '/' && s.isVerbose(p[1:]) {
+		log.Printf("HTTP: start: %s\n", u.String())
+		defer log.Printf("HTTP: done: %s\n", u.String())
 	}
 
-	respond := func(id int, p string) (int, error) {
-		return writeConn([]byte(fmt.Sprintf(`{"id":%d,"result":%s}`, id, p)))
-	}
-
-	go func() {
+	switch u := r.URL; {
+	case u.Path == "/":
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `go to <b>chrome://devtools/bundled/inspector.html?experiments=true&ws=localhost:9229/cdp</b>`)
+	case u.Path == "/json":
+		// https://chromedevtools.github.io/devtools-protocol/#get-json-or-jsonlist
+		s.metadata(w, r)
+	case u.Path == "/cdp":
+		// The endpoint, DevTools connects to to listen for the CDP events
+		// It's a bidirectional Websocket connection,
+		// which translates events from `eventReader` to CDP protocol
+		conn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			errr := fmt.Errorf("HTTP: ws.Upgrader: Upgrade: error=%q", err)
+			http.Error(w, errr.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		ctx, cancel_Fn := context.WithCancel(r.Context())
+		defer conn.Close()
 		defer cancel_Fn()
+
+		if err := s.handleConn(ctx, conn); err != nil {
+			log.Printf("handleConn: error=%q\n", err)
+		}
+	}
+}
+
+func (s *Server) handleConn(ctx context.Context, conn *websocket.Conn) error {
+	// NOTE: make sure to not block the goroutines to be able to errc <- err
+	var errc = make(chan error, 2)
+	go func() {
+		er := s.Eventbus.NewReader()
+		defer er.Close()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			default:
-				var msg event
-				if err := websocket.ReadJSON(conn, &msg); err != nil {
-					log.Printf("ws.ReadJSON: error=%q", err)
+				var e event
+				if err := er.ReadEvent(ctx, &e); err != nil {
+					errc <- fmt.Errorf("eventbus.ReadEvent: %w", err)
 					return
 				}
-				cdpEventsc <- msg
-			}
-		}
-	}()
-
-	// https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
-	// conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"method": "Page.disable","params":{}}`)))
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case e := <-httpEventsc:
-			log.Printf("[HTTP->] %s", e.Method)
-			if e.Method == "_Data.chunk" {
-				data, ok := e.Params.([]byte)
-				if !ok {
-					continue
-				}
-				buf, ok := bodystore[e.reqID]
-				if !ok {
-					buf = new(bytes.Buffer)
-					bodystore[e.reqID] = buf
-				}
-				if _, err := buf.Write(data); err != nil {
-					log.Printf("buf.Write: error=%q", err)
-				}
-				continue
-			}
-
-			if err := websocket.WriteJSON(conn, e); err != nil {
-				log.Printf("writeEvent: error=%q", err)
-				return err
-			}
-		case msg := <-cdpEventsc:
-			log.Printf("[CDP->] %+v", msg)
-			switch m := msg.Method; {
-			case m == "Page.canScreencast" ||
-				m == "Network.canEmulateNetworkConditions" ||
-				m == "Emulation.canEmulate":
-
-				respond(msg.ID, `{"result":false}`)
-			case m == "Page.getResourceTree":
-				// Window decoration
-				payload := `{"frameTree": { "frame":{"id":1,"url":"http://cdp-proxy","mimeType":"other"},"childFrames":[],"resources":[]}}`
-				respond(msg.ID, payload)
-			case m == "Network.getResponseBody":
-				params, ok := msg.Params.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				msg.reqID, ok = params["requestId"].(string)
-				if !ok {
-					continue
-				}
-				buf, ok := bodystore[msg.reqID]
-				if !ok {
-					respond(msg.ID, `{"body":"","base64Encoded":true}`)
-				} else {
-					result := map[string]interface{}{
-						"base64Encoded": true,
-						"body":          base64.StdEncoding.Strict().EncodeToString(buf.Bytes()),
-					}
-
-					data, err := json.Marshal(result)
-					if err != nil {
-						log.Printf("json.Marshal: error=%q", err)
+				// events coming from mitm proxy
+				log.Printf("[MITM->] %s", e.Method)
+				if e.Method == "_Data.chunk" {
+					data, ok := e.Params.([]byte)
+					if !ok {
 						continue
 					}
 
-					// https://chromedevtools.github.io/devtools-protocol/1-2/Network#method-getResponseBody
-					respond(msg.ID, string(data))
+					var newBuf bytes.Buffer
+					buf, ok := store.LoadOrStore(e.reqID, &newBuf)
+
+					if _, err := buf.Write(data); err != nil {
+						log.Printf("buf.Write: error=%q", err)
+					}
+					continue
 				}
-			default:
-				respond(msg.ID, `{}`)
+
+				if err := websocket.WriteJSON(conn, e); err != nil {
+					errc <- fmt.Errorf("websocket.WriteJSON: %w", err)
+					return
+				}
 			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				var e event
+				if err := websocket.ReadJSON(conn, &e); err != nil {
+					errc <- fmt.Errorf("websocket.ReadJSON: %w", err)
+					return
+				}
+				log.Printf("[CDP->] %+v\n", e)
+				if err := handleCDP(ctx, conn, e); err != nil {
+					errc <- fmt.Errorf("handleCDP: %w", err)
+					return
+				}
+			}
+		}
+	}()
+
+	for {
+		select {
+		case err := <-errc:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/main/cdp-proxy/main.go
+++ b/main/cdp-proxy/main.go
@@ -1,17 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
-	"fmt"
-	"io"
 	"log"
-	"net"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"os/signal"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -20,28 +15,43 @@ import (
 )
 
 var (
-	HTTP_CDP_Addr   = "localhost:9229"
-	HTTP_Proxy_Addr = "localhost:8080"
+	HTTP_CDP_HostPort   = "localhost:9229"
+	HTTP_Proxy_HostPort = "localhost:8080"
 )
 
 func main() {
-	flag.StringVar(&HTTP_CDP_Addr, "http-cdp-addr", HTTP_CDP_Addr, "chrome devtools protocol listener address")
-	flag.StringVar(&HTTP_Proxy_Addr, "http-proxy-addr", HTTP_Proxy_Addr, "HTTP proxy listener address")
+	flag.StringVar(&HTTP_CDP_HostPort, "http-cdp-addr", HTTP_CDP_HostPort, "Chrome Devtools Protocol(CDP) listener address(host:port)")
+	flag.StringVar(&HTTP_Proxy_HostPort, "http-proxy-addr", HTTP_Proxy_HostPort, "HTTP proxy listener address(host:port)")
 	flag.Parse()
 
-	var eb = httpcdp.NewEventBus()
+	var (
+		eb             = httpcdp.NewEventBus()
+		ctx, cancel_Fn = context.WithCancel(context.Background())
+	)
+	defer cancel_Fn()
 
 	go func() {
-		log.Printf("http.devtools: ListenAndServe.address=%q", HTTP_CDP_Addr)
-		if err := http.ListenAndServe(HTTP_CDP_Addr, httpcdp.Devtools(eb)); err != nil {
-			log.Fatalf("http.devtools: ListenAndServe.error=%q", err)
+		var (
+			px = "devtools: http.ListenAndServe:"
+			s  = httpcdp.Server{
+				Eventbus: eb,
+				HostPort: HTTP_CDP_HostPort,
+			}
+		)
+		defer log.Printf("%s done", px)
+		log.Printf("%s address=%q", px, HTTP_CDP_HostPort)
+
+		if err := s.ListenAndServe(ctx); err != nil {
+			log.Fatalf("%s error=%q", px, err)
 		}
 	}()
 
 	go func() {
-		log.Printf("http.proxy: ListenAndServe.address=%q", HTTP_Proxy_Addr)
-		if err := http.ListenAndServe(HTTP_Proxy_Addr, httpx.Handler(eb, proxy)); err != nil {
-			log.Fatalf("http.proxy: ListenAndServe.error=%q", err)
+		px := "proxy: http.ListenAndServe:"
+		defer log.Printf("%s done", px)
+		log.Printf("%s address=%q", px, HTTP_Proxy_HostPort)
+		if err := http.ListenAndServe(HTTP_Proxy_HostPort, httpx.Handler(eb, proxy)); err != nil {
+			log.Fatalf("%s error=%q", px, err)
 		}
 	}()
 
@@ -50,110 +60,4 @@ func main() {
 	defer signal.Stop(sigc)
 
 	log.Printf("os: signal=%v", <-sigc)
-}
-
-var proxy = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	u := *r.URL
-	u.Host = r.Host
-	u.Scheme = "http"
-
-	if _, p, _ := net.SplitHostPort(r.Host); p == "443" {
-		u.Scheme = "https"
-	}
-
-	log.Printf("[proxy] %s", u.String())
-
-	if r.Method == http.MethodConnect {
-		newTunnel(&u).ServeHTTP(w, r)
-	} else {
-		newReverseProxy(&u).ServeHTTP(w, r)
-	}
-})
-
-func newTunnel(u *url.URL) http.Handler {
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		httpErr := func(code int, err error) {
-			log.Printf("[CONNECT]: error=%v", err)
-			http.Error(w, http.StatusText(code), code)
-		}
-		defer log.Printf("[CONNECT]: %s: done", u.Host)
-		log.Printf("[CONNECT]: %s", u.Host)
-
-		dconn, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
-		if err != nil {
-			httpErr(http.StatusServiceUnavailable, err)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
-		} else {
-			log.Println("http.Flusher: unavailable")
-		}
-
-		var sconn net.Conn
-		if h, ok := w.(http.Hijacker); !ok {
-			httpErr(http.StatusInternalServerError, fmt.Errorf("http.Hijacker: unavailable"))
-			return
-		} else {
-			conn, _, err := h.Hijack()
-			if err != nil {
-				httpErr(http.StatusServiceUnavailable, err)
-				return
-			}
-			sconn = conn
-		}
-
-		type ReadWriteCloser interface {
-			net.Conn
-			CloseRead() error
-			CloseWrite() error
-		}
-
-		var src, dst = sconn.(ReadWriteCloser), dconn.(ReadWriteCloser)
-		// TODO:
-		var done = make(chan struct{})
-		go func() {
-			n, err := io.Copy(src, dst)
-			log.Printf("src<-dst: n=%d error=%v", n, err)
-			dst.CloseRead()
-			src.CloseWrite()
-			done <- struct{}{}
-		}()
-		go func() {
-			n, err := io.Copy(dst, src)
-			log.Printf("src->dst: n=%d error=%v", n, err)
-			dst.CloseWrite()
-			src.CloseRead()
-			done <- struct{}{}
-		}()
-		<-done
-		<-done
-	})
-}
-
-func newReverseProxy(target *url.URL) *httputil.ReverseProxy {
-	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			// TODO:
-			req.Host = target.Host
-			if _, ok := req.Header["User-Agent"]; !ok {
-				req.Header.Set("User-Agent", "")
-			}
-		},
-		// Transport: loggingTransport(http.DefaultTransport.RoundTrip),
-	}
-}
-
-type loggingTransport func(*http.Request) (*http.Response, error)
-
-func (lt loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	bs, _ := httputil.DumpRequestOut(r, false)
-	log.Println("REQ:", string(bs))
-	re, err := lt(r)
-	bs, _ = httputil.DumpResponse(re, false)
-	log.Println("RES:", string(bs))
-	return re, err
 }


### PR DESCRIPTION
and reorg. Addresses some TODOs

## Problem
Previously, 1+ concurrent CDP clients would race for the events coming from event.
The backend would randomly "load balance" between them.

## Solution
Copy events to each connected client.

 ## Also
 - some cleanup and reorg, still WIP